### PR TITLE
Add ChainFailures to handle nested interactor failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,27 @@
-FROM ruby:2.3.1-alpine
+FROM ruby:2.5.1-alpine
 MAINTAINER Ryan Schlesinger <ryan@outstand.com>
 
-RUN addgroup metaractor && \
-    adduser -S -G metaractor metaractor
-
-ENV GOSU_VERSION 1.9
-ENV DUMB_INIT_VERSION 1.0.3
-
-RUN apk add --no-cache ca-certificates gnupg && \
-    mkdir -p /tmp/build && \
-    cd /tmp/build && \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
-    curl -o gosu -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" && \
-    curl -o gosu.asc -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" && \
-    gpg --verify gosu.asc && \
-    chmod +x gosu && \
-    cp gosu /bin/gosu && \
-    wget https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_amd64 && \
-    wget https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/sha256sums && \
-    grep dumb-init_${DUMB_INIT_VERSION}_amd64$ sha256sums | sha256sum -c && \
-    chmod +x dumb-init_${DUMB_INIT_VERSION}_amd64 && \
-    cp dumb-init_${DUMB_INIT_VERSION}_amd64 /bin/dumb-init && \
-    cd /tmp && \
-    rm -rf /tmp/build && \
-    apk del gnupg && \
-    rm -rf /root/.gnupg
-
-RUN apk add --no-cache \
-    build-base \
-    git \
-    openssh
-
-COPY Gemfile metaractor.gemspec /metaractor/
-COPY lib/metaractor/version.rb /metaractor/lib/metaractor/
-RUN cd /metaractor \
-    && bundle install \
-    && git config --global push.default simple
-COPY . /metaractor/
-RUN chown -R metaractor:metaractor /metaractor
+RUN addgroup -g 1000 -S metaractor && \
+    adduser -u 1000 -S -s /bin/ash -G metaractor metaractor && \
+    apk add --no-cache \
+      ca-certificates \
+      tini \
+      su-exec \
+      build-base \
+      git \
+      openssh
 
 WORKDIR /metaractor
+RUN chown -R metaractor:metaractor /metaractor
+USER metaractor
 
+COPY --chown=metaractor:metaractor Gemfile metaractor.gemspec /metaractor/
+COPY --chown=metaractor:metaractor lib/metaractor/version.rb /metaractor/lib/metaractor/
+RUN git config --global push.default simple
+COPY --chown=metaractor:metaractor . /metaractor/
+
+USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
-ENV DUMB_INIT_SETSID 0
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["rspec", "spec"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.6'
+services:
+  metaractor:
+    build: .
+    image: outstand/metaractor:dev
+    stdin_open: true
+    tty: true
+    volumes:
+      - bundler-data:/usr/local/bundle
+      - .:/metaractor
+volumes:
+  bundler-data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,12 +1,20 @@
-#!/bin/dumb-init /bin/sh
+#!/bin/sh
 set -e
 
-if [ "$1" = 'rspec' ] || [ "$1" = 'rake' ]; then
-  set -- bundle exec "$@"
+if [ "$(which "$1")" = '' ]; then
+  if [ "$(ls -A /usr/local/bundle/bin)" = '' ]; then
+    echo 'command not in path and bundler not initialized'
+    echo 'running bundle install'
+    su-exec metaractor bundle install
+  fi
 fi
 
 if [ "$1" = 'bundle' ]; then
-  set -- gosu metaractor "$@"
+  set -- su-exec deploy "$@"
+elif ls /usr/local/bundle/bin | grep -q "\b$1\b"; then
+  set -- su-exec deploy bundle exec "$@"
+
+  su-exec metaractor ash -c 'bundle check || bundle install'
 fi
 
 exec "$@"

--- a/lib/metaractor.rb
+++ b/lib/metaractor.rb
@@ -5,6 +5,7 @@ require 'metaractor/parameters'
 require 'metaractor/run_with_context'
 require 'metaractor/context_validity'
 require 'metaractor/chain_failures'
+require 'metaractor/fail_from_context'
 
 module Metaractor
   def self.included(base)

--- a/lib/metaractor.rb
+++ b/lib/metaractor.rb
@@ -4,6 +4,7 @@ require 'metaractor/errors'
 require 'metaractor/parameters'
 require 'metaractor/run_with_context'
 require 'metaractor/context_validity'
+require 'metaractor/chain_failures'
 
 module Metaractor
   def self.included(base)
@@ -36,7 +37,8 @@ module Metaractor
     [
       { module: Metaractor::Errors, method: :include },
       { module: Metaractor::Parameters, method: :include },
-      { module: Metaractor::RunWithContext, method: :include }
+      { module: Metaractor::RunWithContext, method: :include },
+      { module: Metaractor::ChainFailures, method: :prepend }
     ]
   end
 

--- a/lib/metaractor.rb
+++ b/lib/metaractor.rb
@@ -1,6 +1,7 @@
 require 'metaractor/version'
 require 'interactor'
 require 'metaractor/errors'
+require 'metaractor/context_errors'
 require 'metaractor/parameters'
 require 'metaractor/run_with_context'
 require 'metaractor/context_validity'
@@ -39,7 +40,7 @@ module Metaractor
       { module: Metaractor::Errors, method: :include },
       { module: Metaractor::Parameters, method: :include },
       { module: Metaractor::RunWithContext, method: :include },
-      { module: Metaractor::ChainFailures, method: :prepend }
+      { module: Metaractor::ChainFailures, method: :include }
     ]
   end
 

--- a/lib/metaractor/chain_failures.rb
+++ b/lib/metaractor/chain_failures.rb
@@ -1,0 +1,11 @@
+module Metaractor
+  module ChainFailures
+    def call
+      super
+    rescue Interactor::Failure => e
+      context.invalidate! if e.context.invalid?
+      context.fail_with_errors!(messsages: e.context.errors)
+      raise
+    end
+  end
+end

--- a/lib/metaractor/chain_failures.rb
+++ b/lib/metaractor/chain_failures.rb
@@ -1,7 +1,13 @@
 module Metaractor
   module ChainFailures
-    def call
-      super
+    def self.included(base)
+      base.class_eval do
+        around :chain_nested_failures
+      end
+    end
+
+    def chain_nested_failures(interactor)
+      interactor.call
     rescue Interactor::Failure => e
       context.fail_from_context(context: e.context)
       raise

--- a/lib/metaractor/chain_failures.rb
+++ b/lib/metaractor/chain_failures.rb
@@ -3,8 +3,7 @@ module Metaractor
     def call
       super
     rescue Interactor::Failure => e
-      context.invalidate! if e.context.invalid?
-      context.fail_with_errors!(messsages: e.context.errors)
+      context.fail_from_context(context: e.context)
       raise
     end
   end

--- a/lib/metaractor/context_errors.rb
+++ b/lib/metaractor/context_errors.rb
@@ -1,0 +1,37 @@
+module Metaractor
+  module ContextErrors
+    def self.included(base)
+      base.class_eval do
+        attr_writer :errors
+      end
+    end
+
+    def errors
+      @errors ||= []
+    end
+
+    def fail_with_error!(message:)
+      add_error(message: message)
+      fail!
+    end
+
+    def fail_with_errors!(messages:)
+      add_errors(messages: messages)
+      fail!
+    end
+
+    def add_error(message:)
+      add_errors(messages: Array(message))
+    end
+
+    def add_errors(messages:)
+      self.errors += messages
+    end
+
+    def error_messages
+      errors.join("\n")
+    end
+  end
+end
+
+Interactor::Context.send(:include, Metaractor::ContextErrors)

--- a/lib/metaractor/context_errors.rb
+++ b/lib/metaractor/context_errors.rb
@@ -1,13 +1,11 @@
 module Metaractor
   module ContextErrors
-    def self.included(base)
-      base.class_eval do
-        attr_writer :errors
-      end
-    end
-
     def errors
-      @errors ||= []
+      if super.nil?
+        self.errors = []
+      end
+
+      super
     end
 
     def fail_with_error!(message:)

--- a/lib/metaractor/errors.rb
+++ b/lib/metaractor/errors.rb
@@ -5,16 +5,24 @@ module Metaractor
   class InvalidError < Error; end
 
   module Errors
-    def self.included(base)
-      base.class_eval do
-        extend Forwardable
-        def_delegators :context,
-          :fail_with_error!,
-          :fail_with_errors!,
-          :add_error,
-          :add_errors,
-          :error_messages
-      end
+    def fail_with_error!(*args)
+      context.fail_with_error!(*args)
+    end
+
+    def fail_with_errors!(*args)
+      context.fail_with_errors!(*args)
+    end
+
+    def add_error(*args)
+      context.add_error(*args)
+    end
+
+    def add_errors(*args)
+      context.add_errors(*args)
+    end
+
+    def error_messages
+      context.error_messages
     end
   end
 end

--- a/lib/metaractor/errors.rb
+++ b/lib/metaractor/errors.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module Metaractor
   class Error < StandardError; end
   class InvalidError < Error; end
@@ -5,35 +7,14 @@ module Metaractor
   module Errors
     def self.included(base)
       base.class_eval do
-        before :initialize_errors_array
+        extend Forwardable
+        def_delegators :context,
+          :fail_with_error!,
+          :fail_with_errors!,
+          :add_error,
+          :add_errors,
+          :error_messages
       end
-    end
-
-    def initialize_errors_array
-      context.errors ||= []
-    end
-
-    def fail_with_error!(message:)
-      add_error(message: message)
-      context.fail!
-    end
-
-    def fail_with_errors!(messages:)
-      add_errors(messages: messages)
-      context.fail!
-    end
-
-    def add_error(message:)
-      add_errors(messages: Array(message))
-    end
-
-    def add_errors(messages:)
-      context.errors ||= []
-      context.errors += messages
-    end
-
-    def error_messages
-      context.errors.join("\n")
     end
   end
 end

--- a/lib/metaractor/fail_from_context.rb
+++ b/lib/metaractor/fail_from_context.rb
@@ -1,8 +1,10 @@
 module Metaractor
   module FailFromContext
     def fail_from_context(context:)
+      return if context.equal?(self)
+
       invalidate! if context.invalid?
-      add_errors(messsages: context.errors)
+      add_errors(messages: context.errors)
       @failure = true
     end
   end

--- a/lib/metaractor/fail_from_context.rb
+++ b/lib/metaractor/fail_from_context.rb
@@ -1,0 +1,11 @@
+module Metaractor
+  module FailFromContext
+    def fail_from_context(context:)
+      invalidate! if context.invalid?
+      add_errors(messsages: context.errors)
+      @failure = true
+    end
+  end
+end
+
+Interactor::Context.send(:include, Metaractor::FailFromContext)

--- a/spec/metaractor_spec.rb
+++ b/spec/metaractor_spec.rb
@@ -227,5 +227,71 @@ describe Metaractor do
         expect(result.errors).to include 'Required parameters: (token xor all)'
       end
     end
+
+    context 'nested failures' do
+      let(:child) do
+        Class.new do
+          include Metaractor
+
+          required :a_param
+
+          def call
+            fail_with_error!(message: 'BOOM')
+          end
+        end
+      end
+
+      let(:parent) do
+        Class.new do
+          include Metaractor
+
+          required :child
+          optional :a_param
+
+          def call
+            context.child.call!(a_param: context.a_param)
+          end
+        end
+      end
+
+      let(:simple) do
+        Class.new do
+          include Metaractor
+        end
+      end
+
+      let(:organizer) do
+        Class.new do
+          include Metaractor
+          include Interactor::Organizer
+        end
+      end
+
+      it 'fails the parent context' do
+        result = parent.call(child: child, a_param: :foo)
+        expect(result).to be_failure
+        expect(result.errors).to include 'BOOM'
+      end
+
+      it 'invalidates the parent context' do
+        result = parent.call(child: child)
+        expect(result).to be_failure
+        expect(result).to be_invalid
+        expect(result.errors).to include 'Required parameters: a_param'
+      end
+
+      it 'allows organizers to run normally' do
+        organizer.organize(simple)
+        result = organizer.call(a_param: :foo)
+        expect(result).to be_success
+      end
+
+      it 'allows organizers to fail normally' do
+        organizer.organize(child)
+        result = organizer.call(a_param: :foo)
+        expect(result).to be_failure
+        expect(result.errors).to eq ['BOOM']
+      end
+    end
   end
 end

--- a/spec/metaractor_spec.rb
+++ b/spec/metaractor_spec.rb
@@ -292,6 +292,13 @@ describe Metaractor do
         expect(result).to be_failure
         expect(result.errors).to eq ['BOOM']
       end
+
+      it 'allows organizers to invalidate normally' do
+        organizer.organize(child)
+        result = organizer.call
+        expect(result).to be_failure
+        expect(result.errors).to include 'Required parameters: a_param'
+      end
     end
   end
 end


### PR DESCRIPTION
When a nested interactor raises due to `call!` and a parent interactor is called with `call`, the resulting failure is buried and the context responds `true` to `success?`.

This PR forces the parent interactor's context to fail and copies the error messages and validity state.