### PR TITLE
Allow non-string structured errors

### DIFF
--- a/lib/metaractor/context_errors.rb
+++ b/lib/metaractor/context_errors.rb
@@ -8,26 +8,37 @@ module Metaractor
       super
     end
 
-    def fail_with_error!(message:)
-      add_error(message: message)
+    def fail_with_error!(message: nil, **args)
+      add_error(message: message, **args)
       fail!
     end
 
-    def fail_with_errors!(messages:)
-      add_errors(messages: messages)
+    def fail_with_errors!(messages: [], errors: [])
+      add_errors(messages: messages, errors: errors)
       fail!
     end
 
-    def add_error(message:)
-      add_errors(messages: Array(message))
+    def add_error(message: nil, **args)
+      if message.present?
+        add_errors(messages: Array(message))
+      else
+        add_errors(errors: [**args])
+      end
     end
 
-    def add_errors(messages:)
+    def add_errors(messages: [], errors: [])
       self.errors += messages
+      self.errors += errors
     end
 
     def error_messages
-      errors.join("\n")
+      errors.map do |error|
+        if error.respond_to?(:has_key?) && error.has_key?(:title)
+          error[:title].to_s
+        else
+          error.to_s
+        end
+      end.join("\n")
     end
   end
 end

--- a/lib/metaractor/context_errors.rb
+++ b/lib/metaractor/context_errors.rb
@@ -19,10 +19,10 @@ module Metaractor
     end
 
     def add_error(message: nil, **args)
-      if message.present?
-        add_errors(messages: Array(message))
-      else
+      if message.nil?
         add_errors(errors: [**args])
+      else
+        add_errors(messages: Array(message))
       end
     end
 
@@ -34,7 +34,11 @@ module Metaractor
     def error_messages
       errors.map do |error|
         if error.respond_to?(:has_key?) && error.has_key?(:title)
-          error[:title].to_s
+          if error[:source] != nil
+            "#{error[:source]}: #{error[:title]}"
+          else
+            error[:title].to_s
+          end
         else
           error.to_s
         end

--- a/spec/metaractor_spec.rb
+++ b/spec/metaractor_spec.rb
@@ -228,6 +228,37 @@ describe Metaractor do
       end
     end
 
+    context 'structured errors' do
+      let(:error_test_class) do
+        Class.new do
+          include Metaractor
+
+          optional :user
+
+          def call
+            fail_with_error!(
+              source: '/user',
+              title: 'Bad user'
+            )
+          end
+        end
+      end
+
+      it 'fails with a structured error' do
+        result = error_test_class.call
+        expect(result).to be_failure
+
+        expect(result.errors).to include({
+          source: '/user',
+          title: 'Bad user'
+        })
+
+        expect(result.error_messages).to include(
+          '/user: Bad user'
+        )
+      end
+    end
+
     context 'nested failures' do
       let(:child) do
         Class.new do


### PR DESCRIPTION
This supports using an error response like https://jsonapi.org/format/1.1/#errors