### PR TITLE
Add `allow_blank` and `has_key?`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.1-alpine
+FROM ruby:2.6.5-alpine
 MAINTAINER Ryan Schlesinger <ryan@outstand.com>
 
 RUN addgroup -g 1000 -S metaractor && \

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ As optional parameters have no enforcement, they are merely advisory.
 optional :enable_logging
 ```
 
+### Skipping Blank Parameter Removal
+By default Metaractor removes blank values that are passed in. You may skip this behavior on a per-parameter basis:
+```ruby
+allow_blank :name
+```
+
+You may check to see if a parameter exists via `context.has_key?`.
+
 ### Custom Validation
 Metaractor supports doing custom validation before any user supplied before_hooks run.
 ```ruby

--- a/lib/metaractor.rb
+++ b/lib/metaractor.rb
@@ -7,6 +7,7 @@ require 'metaractor/run_with_context'
 require 'metaractor/context_validity'
 require 'metaractor/chain_failures'
 require 'metaractor/fail_from_context'
+require 'metaractor/context_has_key'
 
 module Metaractor
   def self.included(base)

--- a/lib/metaractor/context_has_key.rb
+++ b/lib/metaractor/context_has_key.rb
@@ -1,0 +1,9 @@
+module Metaractor
+  module ContextHasKey
+    def has_key?(key)
+      @table.has_key?(key.to_sym)
+    end
+  end
+end
+
+Interactor::Context.send(:include, Metaractor::ContextHasKey)

--- a/lib/metaractor/parameters.rb
+++ b/lib/metaractor/parameters.rb
@@ -8,6 +8,7 @@ module Metaractor
         class << self
           attr_writer :_required_parameters
           attr_writer :_optional_parameters
+          attr_writer :_allow_blank
         end
 
         before :remove_blank_values
@@ -33,6 +34,14 @@ module Metaractor
         self._optional_parameters += params
       end
 
+      def _allow_blank
+        @_allow_blank ||= []
+      end
+
+      def allow_blank(*params)
+        self._allow_blank += params
+      end
+
       def validate_parameters(*hooks, &block)
         hooks << block if block
         hooks.each {|hook| validate_hooks.push(hook) }
@@ -46,6 +55,8 @@ module Metaractor
     def remove_blank_values
       to_delete = []
       context.each_pair do |k,v|
+        next if self.class._allow_blank.include?(k)
+
         # The following regex is borrowed from Rails' String#blank?
         to_delete << k if (v.is_a?(String) && /\A[[:space:]]*\z/ === v) || v.nil?
       end

--- a/spec/metaractor_spec.rb
+++ b/spec/metaractor_spec.rb
@@ -74,6 +74,8 @@ describe Metaractor do
         Class.new do
           include Metaractor
 
+          allow_blank :special
+
           def call
             context.keys = context.to_h.keys
           end
@@ -108,6 +110,12 @@ describe Metaractor do
       it 'does not remove {}' do
         result = blank_class.call(foo: {})
         expect(result.keys).to include :foo
+      end
+
+      it 'does not remove whitelisted param' do
+        result = blank_class.call(foo: '', special: nil)
+        expect(result.keys).to_not include :foo
+        expect(result.keys).to include :special
       end
     end
 
@@ -329,6 +337,21 @@ describe Metaractor do
         result = organizer.call
         expect(result).to be_failure
         expect(result.errors).to include 'Required parameters: a_param'
+      end
+    end
+
+    describe 'Context#has_key?' do
+      let(:result) do
+        Interactor::Context.new(foo: 'bar', blank: '', nope: nil)
+      end
+
+      it 'correctly identifies existing keys' do
+        expect(result.has_key?(:foo)).to be_truthy
+        expect(result.has_key?('foo')).to be_truthy
+        expect(result.has_key?(:blank)).to be_truthy
+        expect(result.has_key?(:nope)).to be_truthy
+
+        expect(result.has_key?(:bar)).to be_falsy
       end
     end
   end


### PR DESCRIPTION
From README:
### Skipping Blank Parameter Removal
By default Metaractor removes blank values that are passed in. You may skip this behavior on a per-parameter basis:
```ruby
allow_blank :name
```

You may check to see if a parameter exists via `context.has_key?`.