### PR TITLE
Add FailureOutput for human readable errors

### DIFF
--- a/lib/metaractor.rb
+++ b/lib/metaractor.rb
@@ -9,6 +9,7 @@ require 'metaractor/context_validity'
 require 'metaractor/chain_failures'
 require 'metaractor/fail_from_context'
 require 'metaractor/context_has_key'
+require 'metaractor/failure_output'
 
 module Metaractor
   def self.included(base)

--- a/lib/metaractor/failure_output.rb
+++ b/lib/metaractor/failure_output.rb
@@ -1,0 +1,39 @@
+module Metaractor
+  module FailureOutput
+    def self.format_hash(hash)
+      if @hash_formatter.nil?
+        @hash_formatter = ->(hash){ hash.inspect }
+      end
+
+      @hash_formatter.call(hash)
+    end
+
+    def self.hash_formatter=(callable)
+      @hash_formatter = callable
+    end
+
+    def to_s
+      str = ''
+
+      if !context.errors.empty?
+        str << "Errors:\n"
+        str << Metaractor::FailureOutput.format_hash(context.errors.to_h)
+        str << "\n\n"
+      end
+
+      if !context._called.empty?
+        str << "Previously Called:\n"
+        context._called.each do |interactor|
+          str << interactor.class.name.to_s
+        end
+        str << "\n\n"
+      end
+
+      str << "Context:\n"
+      str << Metaractor::FailureOutput.format_hash(context.to_h.reject{|k,_| k == :errors})
+      str
+    end
+  end
+end
+
+Interactor::Failure.send(:include, Metaractor::FailureOutput)


### PR DESCRIPTION
Turns this:
```
Interactor::Failure:
       #<Interactor::Context errors=#<Metaractor::Errors:0x000055a3bffe6588 @tree=#<Sycamore::Tree:0x2ad1dfff32b0 {:base=>"NOPE"}>>, parent=true, chained=true>
```

Into this:
```
Interactor::Failure:
       Errors:
       {:base=>"NOPE"}

       Previously Called:
       Chained

       Context:
       {:parent=>true, :chained=>true}
```

It also allows the integrator to choose a different error formatter like so:
```ruby
# Configure FailureOutput to use awesome_print
Metaractor::FailureOutput.hash_formatter = ->(hash) { hash.ai }
```