### PR TITLE
Fix Previously Called output with multiple entries

### DIFF
--- a/lib/metaractor/failure_output.rb
+++ b/lib/metaractor/failure_output.rb
@@ -25,8 +25,9 @@ module Metaractor
         str << "Previously Called:\n"
         context._called.each do |interactor|
           str << interactor.class.name.to_s
+          str << "\n"
         end
-        str << "\n\n"
+        str << "\n"
       end
 
       str << "Context:\n"


### PR DESCRIPTION
Oops.

Before:
```
Errors:
{:base=>"NOPE"}

Previously Called:
ChainedAnother

Context:
{:parent=>true, :chained=>true, :another=>true}
```

After:
```
Errors:
{:base=>"NOPE"}

Previously Called:
Chained
Another

Context:
{:parent=>true, :chained=>true, :another=>true}
```