### PR TITLE
Add first class Parameter with options

### DIFF
--- a/lib/metaractor/parameters.rb
+++ b/lib/metaractor/parameters.rb
@@ -1,3 +1,5 @@
+# Special thanks to the `hashie` and `active_attr` gems for code and inspiration.
+
 module Metaractor
   module Parameters
     def self.included(base)
@@ -6,40 +8,92 @@ module Metaractor
         include Metaractor::HandleErrors
 
         class << self
-          attr_writer :_required_parameters
-          attr_writer :_optional_parameters
-          attr_writer :_allow_blank
+          attr_writer :requirement_trees
         end
 
         before :remove_blank_values
+        before :apply_defaults
         before :validate_required_parameters
       end
     end
 
+    class Parameter
+      include Comparable
+
+      attr_reader :name
+
+      def initialize(name, **options)
+        @name = name.to_sym
+        @options = options
+      end
+
+      def <=>(other)
+        return nil unless other.instance_of? self.class
+        return nil if name == other.name && options != other.options
+        self.name.to_s <=> other.name.to_s
+      end
+
+      def [](key)
+        @options[key]
+      end
+
+      def dig(name, *names)
+        @options.dig(name, *names)
+      end
+
+      def merge!(**options)
+        @options.merge!(**options)
+      end
+
+      def to_s
+        name.to_s
+      end
+
+      def to_sym
+        name
+      end
+
+      protected
+      attr_reader :options
+    end
+
     module ClassMethods
-      def _required_parameters
-        @_required_parameters ||= []
+      def parameter(name, **options)
+        if param = self.parameter_hash[name.to_sym]
+          param.merge!(**options)
+        else
+          Parameter.new(name, **options).tap do |parameter|
+            self.parameter_hash[parameter.name] = parameter
+          end
+        end
       end
 
-      def required(*params)
-        self._required_parameters += params
-      end
-      alias_method :required_parameters, :required
-
-      def _optional_parameters
-        @_optional_parameters ||= []
+      def parameters(*names, **options)
+        names.each do |name|
+          parameter(name, **options)
+        end
       end
 
-      def optional(*params)
-        self._optional_parameters += params
+      def parameter_hash
+        @parameters ||= {}
       end
 
-      def _allow_blank
-        @_allow_blank ||= []
+      def requirement_trees
+        @requirement_trees ||= []
       end
 
-      def allow_blank(*params)
-        self._allow_blank += params
+      def required(*params, **options)
+        if params.empty?
+          tree = options
+          self.requirement_trees << tree
+          parameters(*parameters_in_tree(tree), required: tree)
+        else
+          parameters(*params, required: true, **options)
+        end
+      end
+
+      def optional(*params, **options)
+        parameters(*params, **options)
       end
 
       def validate_parameters(*hooks, &block)
@@ -50,26 +104,74 @@ module Metaractor
       def validate_hooks
         @validate_hooks ||= []
       end
+
+      def parameters_in_tree(tree)
+        if tree.respond_to?(:to_h)
+          tree.to_h.values.first.to_a.flat_map {|t| parameters_in_tree(t)}
+        else
+          [tree]
+        end
+      end
+    end
+
+    def parameters
+      self.class.parameter_hash
+    end
+
+    def requirement_trees
+      self.class.requirement_trees
+    end
+
+    def requirement_trees=(trees)
+      self.class.requirement_trees=(trees)
     end
 
     def remove_blank_values
       to_delete = []
-      context.each_pair do |k,v|
-        next if self.class._allow_blank.include?(k)
+      context.each_pair do |name, value|
+        next if parameters.dig(name, :allow_blank)
 
         # The following regex is borrowed from Rails' String#blank?
-        to_delete << k if (v.is_a?(String) && /\A[[:space:]]*\z/ === v) || v.nil?
+        to_delete << name if (value.is_a?(String) && /\A[[:space:]]*\z/ === value) || value.nil?
       end
-      to_delete.each do |k|
-        context.delete_field k
+
+      to_delete.each do |name|
+        context.delete_field name
+      end
+    end
+
+    def apply_defaults
+      parameters.each do |name, parameter|
+        next unless parameter[:default]
+
+        unless context.has_key?(name)
+          context[name] = _parameter_default(name)
+        end
+      end
+    end
+
+    def _parameter_default(name)
+      default = self.parameters[name][:default]
+
+      case
+      when default.respond_to?(:call) then instance_exec(&default)
+      when default.respond_to?(:dup) then default.dup
+      else default
       end
     end
 
     def validate_required_parameters
       context.errors ||= []
 
-      self.class._required_parameters.each do |param|
-        require_parameter param
+      parameters.each do |name, parameter|
+        next if !parameter[:required] ||
+          parameter[:required].is_a?(Hash)
+
+        require_parameter name
+      end
+
+      requirement_trees.each do |tree|
+        require_parameter tree
       end
 
       run_validate_hooks

--- a/spec/metaractor_spec.rb
+++ b/spec/metaractor_spec.rb
@@ -74,7 +74,7 @@ describe Metaractor do
         Class.new do
           include Metaractor
 
-          allow_blank :special
+          parameter :special, allow_blank: true
 
           def call
             context.keys = context.to_h.keys
@@ -116,6 +116,33 @@ describe Metaractor do
         result = blank_class.call(foo: '', special: nil)
         expect(result.keys).to_not include :foo
         expect(result.keys).to include :special
+      end
+    end
+
+    context 'parameter defaults' do
+      let(:defaults_class) do
+        Class.new do
+          include Metaractor
+
+          required :name
+          parameter :foo, default: -> { context.name }
+          optional :bar, default: 'a string'
+          optional :shared_default, default: 'a string'
+
+          def call
+          end
+        end
+      end
+
+      it 'applies defaults' do
+        result = defaults_class.call!(name: 'Best Defaults')
+        expect(result.foo).to eq 'Best Defaults'
+        expect(result.bar).to eq 'a string'
+        expect(result.shared_default).to eq 'a string'
+
+        result.bar = 'different'
+        expect(result.bar).to eq 'different'
+        expect(result.shared_default).to eq 'a string'
       end
     end
 
@@ -234,6 +261,64 @@ describe Metaractor do
         expect(result).to_not be_valid
         expect(result.error_messages).to include 'Required parameters: (token xor all)'
       end
+    end
+
+    context 'parameter options' do
+      let(:options_class) do
+        Class.new do
+          include Metaractor
+
+          required or: [:token, or: [:recipient_id, :recipient] ]
+          parameter :token, allow_blank: true
+          parameter :thing, required: true
+          required :foo, allow_blank: true
+          optional :bar, default: 'a string'
+
+          def call
+            context.keys = context.to_h.keys
+          end
+        end
+      end
+
+      it 'correctly tracks declared parameters' do
+        action = options_class.new
+
+        expect(action.requirement_trees).to contain_exactly({
+          or: [:token, or: [:recipient_id, :recipient] ]
+        })
+        tree = action.requirement_trees.first
+
+        expect(action.parameters).to eq(
+          token: Metaractor::Parameters::Parameter.new(:token, allow_blank: true, required: tree),
+          recipient_id: Metaractor::Parameters::Parameter.new(:recipient_id, required: tree),
+          recipient: Metaractor::Parameters::Parameter.new(:recipient, required: tree),
+          thing: Metaractor::Parameters::Parameter.new(:thing, required: true),
+          foo: Metaractor::Parameters::Parameter.new(:foo, required: true, allow_blank: true),
+          bar: Metaractor::Parameters::Parameter.new(:bar, default: 'a string')
+        )
+      end
+
+      it 'fails without required parameters' do
+        result = options_class.call
+        expect(result).to be_failure
+        expect(result).to_not be_valid
+        expect(result.error_messages).to contain_exactly(
+          'Required parameters: (token or (recipient_id or recipient))',
+          'Required parameters: thing',
+          'Required parameters: foo'
+        )
+      end
+
+      it 'removes blank params' do
+        result = options_class.call!(token: '', thing: 'asdf', foo: '', extra: nil)
+        expect(result.keys).to include(:token, :thing, :foo)
+      end
+
+      it 'sets defaults' do
+        result = options_class.call!(token: '', thing: 'asdf', foo: '')
+        expect(result.bar).to eq 'a string'
+      end
+
     end
 
     context 'structured errors' do

--- a/spec/metaractor_spec.rb
+++ b/spec/metaractor_spec.rb
@@ -273,6 +273,7 @@ describe Metaractor do
           parameter :thing, required: true
           required :foo, allow_blank: true
           optional :bar, default: 'a string'
+          optional :baz, default: 'a string', allow_blank: true
 
           def call
             context.keys = context.to_h.keys
@@ -294,7 +295,8 @@ describe Metaractor do
           recipient: Metaractor::Parameters::Parameter.new(:recipient, required: tree),
           thing: Metaractor::Parameters::Parameter.new(:thing, required: true),
           foo: Metaractor::Parameters::Parameter.new(:foo, required: true, allow_blank: true),
-          bar: Metaractor::Parameters::Parameter.new(:bar, default: 'a string')
+          bar: Metaractor::Parameters::Parameter.new(:bar, default: 'a string'),
+          baz: Metaractor::Parameters::Parameter.new(:baz, default: 'a string', allow_blank: true)
         )
       end
 
@@ -310,15 +312,14 @@ describe Metaractor do
       end
 
       it 'removes blank params' do
-        result = options_class.call!(token: '', thing: 'asdf', foo: '', extra: nil)
-        expect(result.keys).to include(:token, :thing, :foo)
+        result = options_class.call!(token: '', thing: 'asdf', foo: '', extra: nil, baz: '')
+        expect(result.keys).to include(:token, :thing, :foo, :baz)
       end
 
       it 'sets defaults' do
         result = options_class.call!(token: '', thing: 'asdf', foo: '')
         expect(result.bar).to eq 'a string'
       end
-
     end
 
     context 'structured errors' do


### PR DESCRIPTION
`Metaractor#parameters` is now an introspectable list of the declared parameters.

Example:
```ruby
required or: [:token, or: [:recipient_id, :recipient] ]
parameter :token, allow_blank: true
parameter :thing, required: true
required :foo, allow_blank: true
optional :bar, default: 'a string'
optional :another, default: -> { context.thing }
```

You can mix and match `required`, `optional`, and `parameter`. The three currently supported param options are `required`, `allow_blank`, and `default`.