### PR TITLE
Update README and fix issues found while writing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ result.failure?
 # => true
 result.valid?
 # => false
-result.errors
+result.error_messages
 # => ["Required parameters: (user_id or user)"]
 ```
 
@@ -68,19 +68,40 @@ Metaractor supports complex required parameter statements and you can chain thes
 required and: [:token, or: [:recipient_id, :recipient] ]
 ```
 
+You can also mark a parameter as required with the `required` option:
+```ruby
+parameter :user, required: true
+```
+
 ### Optional Parameters
 As optional parameters have no enforcement, they are merely advisory.
 ```ruby
 optional :enable_logging
 ```
 
-### Skipping Blank Parameter Removal
+### Parameter Options
+Metaractor supports arbitrary parameter options. The following are currently built in.
+Note that you can specify a block of `required` or `optional` parameters and then use
+`parameter` or `parameters` to add options to one or more of them.
+
+#### Skipping Blank Parameter Removal
 By default Metaractor removes blank values that are passed in. You may skip this behavior on a per-parameter basis:
 ```ruby
-allow_blank :name
+parameter :name, allow_blank: true
 ```
 
 You may check to see if a parameter exists via `context.has_key?`.
+
+#### Default Values
+You can specify a default value for a parameter:
+```ruby
+optional :role, default: :user
+```
+
+This works with `allow_blank` and can also be anything that responds to `#call`.
+```ruby
+parameter :role, allow_blank: true, default: -> { context.default_role }
+```
 
 ### Custom Validation
 Metaractor supports doing custom validation before any user supplied before_hooks run.
@@ -161,6 +182,64 @@ result.errors.to_h
 #    }
 ```
 
+### I18n
+As of v3.0.0, metaractor supports i18n along with structured errors.
+```ruby
+module Users
+  class UpdateUser
+    include Metaractor
+
+    optional :is_admin
+    optional :user
+
+    def call
+      fail_with_error!(
+        errors: {
+          base: :invalid_configuration,
+          is_admin: :true_or_false,
+          user: [ title: :blank, username: [:unique, :blank] ]
+        }
+      )
+    end
+  end
+end
+```
+
+Locale:
+```yaml
+en:
+  errors:
+    parameters:
+      invalid_configuration: 'Invalid configuration'
+      blank: '%{parameter} cannot be blank'
+      unique: '%{parameter} must be unique'
+
+      users:
+        is_admin:
+          true_or_false: 'must be true or false'
+      user:
+        username:
+          unique: 'Username has already been taken'
+```
+
+Metaractor will attempt to use the namespace of the code that reported the error.
+You can see that above with the `users` key in the locale.
+
+The i18n integration will walk its way from the most specific message to the least specific one, stopping at the first one it can find.
+We currently expose the following variables for use in the message:
+- `error_key`: the error we added (ex: `blank` or `invalid_configuration`)
+- `parameter`: the name of the parameter
+
+You can also use this feature to work with machine readable keys:
+```ruby
+result = Users::UpdateUser.call
+if result.failure? &&
+  result.errors[:is_admin] == :true_or_false
+
+  # handle this specific case
+end
+```
+
 ### Spec Helpers
 Enable the helpers and/or matchers:
 ```ruby
@@ -221,8 +300,8 @@ expect(result).to include_errors(
 expect(result).to include_errors('user.title cannot be blank')
 ```
 
-### Error Output
-Metaractor customizes the exception message for `Interactor::Failure`:
+### Hash Formatting
+Metaractor customizes the output for `Metaractor::Errors#inspect` and `Interactor::Failure`:
 ```
 Interactor::Failure:
        Errors:
@@ -235,10 +314,12 @@ Interactor::Failure:
        {:parent=>true, :chained=>true}
 ```
 
-You can further customize the exception message:
+You can further customize the hash formatting:
 ```ruby
-# Configure FailureOutput to use awesome_print
-Metaractor::FailureOutput.hash_formatter = ->(hash) { hash.ai }
+Metaractor.configure do |config|
+  # Configure Metaractor to use awesome_print
+  config.hash_formatter = ->(hash) { hash.ai }
+end
 ```
 
 ### Further Reading

--- a/lib/metaractor/errors.rb
+++ b/lib/metaractor/errors.rb
@@ -21,19 +21,24 @@ module Metaractor
 
             names = object.class.i18n_parent_names
             until names.empty?
-              defaults << :"errors.#{names.join('.')}.parameters.#{path_elements.join('.')}.#{@value}"
+              defaults << ['errors', names.join('.'), 'parameters', path_elements.join('.'), @value.to_s].reject do |item|
+                item.nil? || item == ''
+              end.join('.').to_sym
               names.pop
             end
           end
 
-          defaults << :"errors.parameters.#{path_elements.join('.')}.#{@value}"
+          unless path_elements.empty?
+            defaults << :"errors.parameters.#{path_elements.join('.')}.#{@value}"
+          end
+          defaults << :"errors.parameters.#{@value}"
 
           key = defaults.shift
           I18n.translate(
             key,
             default: defaults,
             error_key: @value,
-            path_elements: path_elements
+            parameter: path_elements.last
           )
         else
           "#{path_elements.join('.')} #{@value}".lstrip

--- a/spec/metaractor_spec.rb
+++ b/spec/metaractor_spec.rb
@@ -429,10 +429,14 @@ describe Metaractor do
             'Authorization::Roles::CheckRole'
           end
 
+          optional :role, :user
+
           def call
             fail_with_error!(
               errors: {
-                role: :mismatched_role
+                base: :internal_error,
+                role: :mismatched_role,
+                user: :blank
               }
             )
           end
@@ -444,6 +448,8 @@ describe Metaractor do
           :en,
           errors: {
             parameters: {
+              blank: '%{parameter} cannot be blank',
+              internal_error: 'Internal Error',
               role: {
                 mismatched_role: 'Least specific error'
               }
@@ -504,6 +510,8 @@ describe Metaractor do
         result = test_class.call
         expect(result).to be_failure
 
+        expect(result).to include_errors('user cannot be blank')
+        expect(result).to include_errors('Internal Error')
         expect(result.errors).to include(:role)
         expect(result).to include_errors('Super specific error')
       end


### PR DESCRIPTION
See README for documentation.

I discovered that we weren't handling errors on `base` correctly nor were we supporting generic translations correctly.