### PR TITLE
Add type casting

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,91 @@
+env:
+  BUILDKITE_PLUGIN_DOCKER_CACHE_S3_BUCKET: "outstand-buildkite-cache"
+  # BUILDKITE_PLUGIN_DOCKER_CACHE_VOLUME_DEBUG: "true"
+  BUILDKITE_PLUGIN_DOCKER_COMPOSE_SHELL: "false"
+  # BUILDKITE_PLUGIN_DOCKER_COMPOSE_UPLOAD_CONTAINER_LOGS: "always"
+  BUILDKITE_PLUGIN_DOCKER_COMPOSE_PULL_RETRIES: 5
+  BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_RETRIES: 5
+  PLUGIN_DOCKER_COMPOSE_VERSION: "17bac3aaee1360e39381b89bb45513b11838238e"
+  PLUGIN_DOCKER_CACHE_VERSION: "f3d8feb52a25c69c75565e9f0b80375eae51850a"
+
+steps:
+  - label: ":docker: Build :rails:"
+    command: ./docker/ci-prep.sh
+    key: build
+    plugins:
+      - seek-oss/aws-sm#v2.2.1:
+          env:
+            DOCKER_LOGIN_PASSWORD: "/buildkite/docker_password"
+
+      - docker-login#v2.0.1:
+          username: outstandci
+
+      - ecr#v2.1.1:
+          login: true
+          region: "us-east-1"
+
+      - https://github.com/outstand/docker-compose-buildkite-plugin.git#${PLUGIN_DOCKER_COMPOSE_VERSION}:
+          build: metaractor
+          image-repository: 786715713882.dkr.ecr.us-east-1.amazonaws.com/ci-images
+          config:
+            - docker-compose.yml
+
+  - label: ":bundler: :rubygems:"
+    key: bundle_install
+    command: bundle install
+    depends_on: build
+    plugins:
+      - seek-oss/aws-sm#v2.2.1:
+          env:
+            DOCKER_LOGIN_PASSWORD: "/buildkite/docker_password"
+
+      - docker-login#v2.0.1:
+          username: outstandci
+
+      - ecr#v2.1.1:
+          login: true
+          region: "us-east-1"
+
+      - https://github.com/outstand/docker-compose-buildkite-plugin.git#${PLUGIN_DOCKER_COMPOSE_VERSION}:
+          run: metaractor
+          dependencies: false
+          config:
+            - docker-compose.yml
+
+      - https://github.com/outstand/docker-cache-buildkite-plugin.git#${PLUGIN_DOCKER_CACHE_VERSION}:
+          name: bundler-cache
+          keys:
+            - v1-bundler-cache-{{ arch }}-{{ checksum "metaractor.gemspec" }}-{{ checksum "Gemfile" }}
+            - v1-bundler-cache-{{ arch }}-
+          save: true
+          volumes:
+            - bundler-data
+
+  - label: ":ruby: Specs"
+    command: rspec spec
+    plugins:
+      - seek-oss/aws-sm#v2.2.1:
+          env:
+            DOCKER_LOGIN_PASSWORD: "/buildkite/docker_password"
+          json-to-env:
+            - secret-id: "/buildkite/rails/env_vars"
+
+      - docker-login#v2.0.1:
+          username: outstandci
+
+      - ecr#v2.1.1:
+          login: true
+          region: "us-east-1"
+
+      - https://github.com/outstand/docker-compose-buildkite-plugin.git#${PLUGIN_DOCKER_COMPOSE_VERSION}:
+          run: metaractor
+          config:
+            - docker-compose.yml
+
+      - https://github.com/outstand/docker-cache-buildkite-plugin.git#${PLUGIN_DOCKER_CACHE_VERSION}:
+          name: bundler-cache
+          keys:
+            - v1-bundler-cache-{{ arch }}-{{ checksum "metaractor.gemspec" }}-{{ checksum "Gemfile" }}
+            - v1-bundler-cache-{{ arch }}-
+          volumes:
+            - bundler-data

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ env:
   PLUGIN_DOCKER_CACHE_VERSION: "f3d8feb52a25c69c75565e9f0b80375eae51850a"
 
 steps:
-  - label: ":docker: Build :rails:"
+  - label: ":docker: Build"
     command: ./docker/ci-prep.sh
     key: build
     plugins:
@@ -63,6 +63,7 @@ steps:
 
   - label: ":ruby: Specs"
     command: rspec spec
+    depends_on: bundle_install
     plugins:
       - seek-oss/aws-sm#v2.2.1:
           env:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/Deskfile

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,4 @@
 --color
 --require spec_helper
+--format progress
+--format RSpec::Buildkite::AnnotationFormatter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+FROM outstand/fixuid as fixuid
+
 FROM ruby:2.7.3-alpine
 LABEL maintainer="Ryan Schlesinger <ryan@outstand.com>"
 
@@ -10,6 +12,13 @@ RUN addgroup -g 1000 -S metaractor && \
       build-base \
       git \
       openssh
+
+COPY --from=fixuid /usr/local/bin/fixuid /usr/local/bin/fixuid
+RUN chmod 4755 /usr/local/bin/fixuid && \
+      USER=metaractor && \
+      GROUP=metaractor && \
+      mkdir -p /etc/fixuid && \
+      printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
 
 ENV BUNDLER_VERSION 2.2.16
 RUN gem install bundler -v ${BUNDLER_VERSION} -i /usr/local/lib/ruby/gems/$(ls /usr/local/lib/ruby/gems) --force

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.5-alpine
+FROM ruby:2.7.3-alpine
 LABEL maintainer="Ryan Schlesinger <ryan@outstand.com>"
 
 RUN addgroup -g 1000 -S metaractor && \
@@ -11,7 +11,7 @@ RUN addgroup -g 1000 -S metaractor && \
       git \
       openssh
 
-ENV BUNDLER_VERSION 2.1.4
+ENV BUNDLER_VERSION 2.2.16
 RUN gem install bundler -v ${BUNDLER_VERSION} -i /usr/local/lib/ruby/gems/$(ls /usr/local/lib/ruby/gems) --force
 
 WORKDIR /metaractor

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
 
 gemspec
-gem 'pry-byebug'
-gem 'awesome_print'
+gem 'rspec-buildkite', github: 'outstand/rspec-buildkite', branch: 'error-output'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Metaractor
+# Metaractor [![Build status](https://badge.buildkite.com/70063a5154eb7366b8b7fd65a875c5f64301bc60f6d29a2ad7.svg)](https://buildkite.com/outstand/metaractor)
 Adds parameter validation and error control to [interactor](https://github.com/collectiveidea/interactor).
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -103,6 +103,24 @@ This works with `allow_blank` and can also be anything that responds to `#call`.
 parameter :role, allow_blank: true, default: -> { context.default_role }
 ```
 
+#### Typecasting/Coersion
+You can supply Metaractor with a callable that will typecast incoming parameters:
+```ruby
+optional :needs_to_be_a_string, type: ->(value) { value.to_s }
+```
+
+You can also configure Metaractor with named types and use them:
+```ruby
+Metaractor.configure do |config|
+  config.register_type(:boolean, ->(value) { ActiveModel::Type::Boolean.new.cast(value) })
+end
+```
+```ruby
+required :is_awesome, type: :boolean
+```
+
+**Note**: Typecasters will _not_ be called on `nil` values.
+
 ### Custom Validation
 Metaractor supports doing custom validation before any user supplied before_hooks run.
 ```ruby

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@ services:
     stdin_open: true
     tty: true
     command: rake release
+    environment:
+      FIXUID:
+      FIXGID:
     volumes:
       - bundler-data:/usr/local/bundle
       - ~/.gitconfig:/home/metaractor/.gitconfig

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     image: outstand/metaractor:dev
     stdin_open: true
     tty: true
+    environment:
+      FIXUID:
+      FIXGID:
     volumes:
       - bundler-data:/usr/local/bundle
       - .:/metaractor

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,18 @@
 #!/bin/sh
+
 set -e
+
+su-exec ${FIXUID:?Missing FIXUID var}:${FIXGID:?Missing FIXGID var} fixuid
+
+chown_dir() {
+  dir=$1
+  if [[ -d ${dir} ]] && [[ "$(stat -c %u:%g ${dir})" != "${FIXUID}:${FIXGID}" ]]; then
+    echo chown $dir
+    chown metaractor:metaractor $dir
+  fi
+}
+
+chown_dir /usr/local/bundle
 
 if [ "$(which "$1")" = '' ]; then
   if [ "$(ls -A /usr/local/bundle/bin)" = '' ]; then

--- a/lib/metaractor.rb
+++ b/lib/metaractor.rb
@@ -77,4 +77,16 @@ module Metaractor
   def self.hash_formatter=(callable)
     @hash_formatter = callable
   end
+
+  def self.types
+    @types ||= {}
+  end
+
+  def self.register_type(type, callable)
+    types[type] = callable
+  end
+
+  def self.clear_types!
+    @types = {}
+  end
 end

--- a/metaractor.gemspec
+++ b/metaractor.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.9'
   spec.add_development_dependency 'awesome_print', '~> 1.8'
   spec.add_development_dependency 'pry-byebug', '~> 3.9'
+  spec.add_development_dependency 'activemodel', '~> 6.1'
 end

--- a/metaractor.gemspec
+++ b/metaractor.gemspec
@@ -11,7 +11,10 @@ Gem::Specification.new do |spec|
   spec.email         = ['ryan@outstand.com']
 
   spec.summary       = %q{Adds parameter validation and error control to interactor}
-  spec.homepage      = 'https://github.com/outstand/metaractor'
+  spec.metadata      = {
+    "homepage_uri" => "https://github.com/outstand/metaractor",
+    "source_code_uri" => "https://github.com/outstand/metaractor"
+  }
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'

--- a/spec/metaractor_spec.rb
+++ b/spec/metaractor_spec.rb
@@ -378,6 +378,8 @@ describe Metaractor do
               allow_blank: true,
               type: ->(value) { raise "BOOM" if value.nil? }
 
+            optional :pow, type: ->(value) { raise "POW" if value.nil? }
+
             def call
             end
           end
@@ -385,10 +387,12 @@ describe Metaractor do
 
         it 'does not typecast nil values' do
           result = types_class.call(
-            boom: nil
+            boom: nil,
+            pow: nil
           )
 
           expect(result.boom).to eq nil
+          expect(result).to_not have_key(:pow)
         end
       end
     end

--- a/spec/metaractor_spec.rb
+++ b/spec/metaractor_spec.rb
@@ -322,6 +322,77 @@ describe Metaractor do
       end
     end
 
+    context 'parameter types' do
+      let(:types_class) do
+        Class.new do
+          include Metaractor
+
+          required :foo, type: ->(value) { value.to_s }
+          optional :job_title,
+            :job_title_required,
+            type: :boolean
+
+          optional :boom,
+            allow_blank: true,
+            type: ->(value) { raise "BOOM" if value.nil? }
+
+          def call
+          end
+        end
+      end
+
+      before do
+        Metaractor.register_type(
+          :boolean,
+          ->(value) { ActiveModel::Type::Boolean.new.cast(value) }
+        )
+      end
+
+      after do
+        Metaractor.clear_types!
+      end
+
+      it 'casts types from a callable' do
+        result = types_class.call(
+          foo: :a_symbol
+        )
+        expect(result.foo).to eq "a_symbol"
+      end
+
+      it 'casts types from a configured type' do
+        result = types_class.call(
+          foo: :a_symbol,
+          job_title: "1",
+          job_title_required: "false"
+        )
+        expect(result.job_title).to eq true
+        expect(result.job_title_required).to eq false
+      end
+
+      context 'with allow_blank' do
+        let(:types_class) do
+          Class.new do
+            include Metaractor
+
+            optional :boom,
+              allow_blank: true,
+              type: ->(value) { raise "BOOM" if value.nil? }
+
+            def call
+            end
+          end
+        end
+
+        it 'does not typecast nil values' do
+          result = types_class.call(
+            boom: nil
+          )
+
+          expect(result.boom).to eq nil
+        end
+      end
+    end
+
     context 'structured errors' do
       let(:error_test_class) do
         Class.new do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'metaractor/spec'
 require 'pry-byebug'
 require 'awesome_print'
+require 'active_model'
 
 Metaractor.hash_formatter = ->(hash) { hash.ai }
 


### PR DESCRIPTION
## Typecasting/Coersion
You can supply Metaractor with a callable that will typecast incoming parameters:
```ruby
optional :needs_to_be_a_string, type: ->(value) { value.to_s }
```

You can also configure Metaractor with named types and use them:
```ruby
Metaractor.configure do |config|
  config.register_type(:boolean, ->(value) { ActiveModel::Type::Boolean.new.cast(value) })
end
```
```ruby
required :is_awesome, type: :boolean
```

**Note**: Typecasters will _not_ be called on `nil` values.

### CI!
This PR also adds CI via buildkite.