### PR TITLE
Allow for default value of false

### DIFF
--- a/lib/metaractor/parameters.rb
+++ b/lib/metaractor/parameters.rb
@@ -38,6 +38,10 @@ module Metaractor
         @options[key]
       end
 
+      def has_key?(key)
+        @options.has_key?(key)
+      end
+
       def dig(name, *names)
         @options.dig(name, *names)
       end

--- a/lib/metaractor/parameters.rb
+++ b/lib/metaractor/parameters.rb
@@ -143,7 +143,7 @@ module Metaractor
 
     def apply_defaults
       parameters.each do |name, parameter|
-        next unless parameter[:default]
+        next unless parameter.has_key?(:default)
 
         unless context.has_key?(name)
           context[name] = _parameter_default(name)

--- a/spec/metaractor_spec.rb
+++ b/spec/metaractor_spec.rb
@@ -128,6 +128,7 @@ describe Metaractor do
           parameter :foo, default: -> { context.name }
           optional :bar, default: 'a string'
           optional :shared_default, default: 'a string'
+          optional :boolean_default, default: false
 
           def call
           end
@@ -139,6 +140,7 @@ describe Metaractor do
         expect(result.foo).to eq 'Best Defaults'
         expect(result.bar).to eq 'a string'
         expect(result.shared_default).to eq 'a string'
+        expect(result.boolean_default).to eq false
 
         result.bar = 'different'
         expect(result.bar).to eq 'different'


### PR DESCRIPTION
When you specify `default: false` for a parameter, it acts as though there is no default set and skips over that parameter.

Example:
```ruby
optional :thing, default: false
```

Expected:
```ruby
context = ThingMetaractor.call
context.thing = false
```

Actual:
```ruby
context = ThingMetaractor.call
context.thing = nil
```

This can cause some strange side-effects because you expect those optional params to be materialized into the context even when they are passed in.