### PR TITLE
Fix Errors#add with SimpleDelegator

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,21 +5,23 @@ env:
   # BUILDKITE_PLUGIN_DOCKER_COMPOSE_UPLOAD_CONTAINER_LOGS: "always"
   BUILDKITE_PLUGIN_DOCKER_COMPOSE_PULL_RETRIES: 5
   BUILDKITE_PLUGIN_DOCKER_COMPOSE_PUSH_RETRIES: 5
-  PLUGIN_DOCKER_COMPOSE_VERSION: "e88235edd25e436a810da1ce161c04237c7a6f2c"
-  PLUGIN_DOCKER_CACHE_VERSION: "ffd18c5910ad402493e8a6614536b4e2b286d665"
+  PLUGIN_DOCKER_COMPOSE_VERSION: "03d746fbf5171b217b732ff7d8a3e417d664df1c"
+  PLUGIN_DOCKER_CACHE_VERSION: "50ecc80f736a4a3a0ab1f5990e58ae8e536c85e1"
+  WORKSPACE_DIR: "${BUILDKITE_BUILD_CHECKOUT_PATH}"
 
 steps:
   - label: ":docker: Build"
     key: build
     plugins:
-      - seek-oss/aws-sm#v2.2.1:
+      - seek-oss/aws-sm#v2.3.1:
           env:
             DOCKER_LOGIN_PASSWORD: "/buildkite/docker_password"
 
-      - docker-login#v2.0.1:
+      - docker-login#v2.1.0:
           username: outstandci
+          retries: 2
 
-      - ecr#v2.1.1:
+      - ecr#v2.5.0:
           login: true
           region: "us-east-1"
 
@@ -27,21 +29,22 @@ steps:
           build: metaractor
           image-repository: 786715713882.dkr.ecr.us-east-1.amazonaws.com/ci-images
           config:
-            - docker-compose.yml
+            - compose.yml
 
   - label: ":bundler: :rubygems:"
     key: bundle_install
     command: bundle install
     depends_on: build
     plugins:
-      - seek-oss/aws-sm#v2.2.1:
+      - seek-oss/aws-sm#v2.3.1:
           env:
             DOCKER_LOGIN_PASSWORD: "/buildkite/docker_password"
 
-      - docker-login#v2.0.1:
+      - docker-login#v2.1.0:
           username: outstandci
+          retries: 2
 
-      - ecr#v2.1.1:
+      - ecr#v2.5.0:
           login: true
           region: "us-east-1"
 
@@ -49,7 +52,7 @@ steps:
           run: metaractor
           dependencies: false
           config:
-            - docker-compose.yml
+            - compose.yml
 
       - https://github.com/outstand/docker-cache-buildkite-plugin.git#${PLUGIN_DOCKER_CACHE_VERSION}:
           name: bundler-cache
@@ -64,23 +67,22 @@ steps:
     command: rspec spec
     depends_on: bundle_install
     plugins:
-      - seek-oss/aws-sm#v2.2.1:
+      - seek-oss/aws-sm#v2.3.1:
           env:
             DOCKER_LOGIN_PASSWORD: "/buildkite/docker_password"
-          json-to-env:
-            - secret-id: "/buildkite/rails/env_vars"
 
-      - docker-login#v2.0.1:
+      - docker-login#v2.1.0:
           username: outstandci
+          retries: 2
 
-      - ecr#v2.1.1:
+      - ecr#v2.5.0:
           login: true
           region: "us-east-1"
 
       - https://github.com/outstand/docker-compose-buildkite-plugin.git#${PLUGIN_DOCKER_COMPOSE_VERSION}:
           run: metaractor
           config:
-            - docker-compose.yml
+            - compose.yml
 
       - https://github.com/outstand/docker-cache-buildkite-plugin.git#${PLUGIN_DOCKER_CACHE_VERSION}:
           name: bundler-cache

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@
 /pkg/
 /spec/reports/
 /tmp/
-/Deskfile

--- a/Deskfile
+++ b/Deskfile
@@ -1,0 +1,3 @@
+rspec() {
+  docker compose run --rm metaractor rspec "$@"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,55 @@
 FROM outstand/fixuid as fixuid
 
-FROM ruby:2.7.3-alpine
+FROM ruby:2.7.6-alpine
 LABEL maintainer="Ryan Schlesinger <ryan@outstand.com>"
 
-RUN addgroup -g 1000 -S metaractor && \
-    adduser -u 1000 -S -s /bin/ash -G metaractor metaractor && \
-    apk add --no-cache \
-      ca-certificates \
-      tini \
-      su-exec \
-      build-base \
-      git \
-      openssh
+RUN set -eux; \
+      \
+      apk add --no-cache \
+        bash
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN set -eux; \
+      \
+      addgroup -g 1000 -S metaractor; \
+      adduser -u 1000 -S -s /bin/ash -G metaractor metaractor; \
+      \
+      apk add --no-cache \
+        ca-certificates \
+        tini \
+        su-exec \
+        build-base \
+        git \
+        openssh
 
 COPY --from=fixuid /usr/local/bin/fixuid /usr/local/bin/fixuid
-RUN chmod 4755 /usr/local/bin/fixuid && \
-      USER=metaractor && \
-      GROUP=metaractor && \
-      mkdir -p /etc/fixuid && \
+RUN set -eux; \
+      \
+      chmod 4755 /usr/local/bin/fixuid; \
+      USER=metaractor; \
+      GROUP=metaractor; \
+      mkdir -p /etc/fixuid; \
       printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
 
-ENV BUNDLER_VERSION 2.2.16
-RUN gem install bundler -v ${BUNDLER_VERSION} -i /usr/local/lib/ruby/gems/$(ls /usr/local/lib/ruby/gems) --force
+ENV BUNDLER_VERSION 2.3.20
+RUN set -eux; \
+      \
+      gem install bundler -v ${BUNDLER_VERSION} -i /usr/local/lib/ruby/gems/$(ls /usr/local/lib/ruby/gems) --force
 
 WORKDIR /metaractor
-RUN chown -R metaractor:metaractor /metaractor
+RUN set -eux; \
+      \
+      chown -R metaractor:metaractor /metaractor
+
 USER metaractor
 
 COPY --chown=metaractor:metaractor Gemfile metaractor.gemspec /metaractor/
 COPY --chown=metaractor:metaractor lib/metaractor/version.rb /metaractor/lib/metaractor/
-RUN git config --global push.default simple
+RUN set -eux; \
+      \
+      git config --global push.default simple
 COPY --chown=metaractor:metaractor . /metaractor/
 
 USER root

--- a/compose.yml
+++ b/compose.yml
@@ -1,4 +1,3 @@
-version: '3.6'
 services:
   metaractor:
     build: .
@@ -15,6 +14,7 @@ services:
     volumes:
       - bundler-data:/usr/local/bundle
       - .:/metaractor
+
   release:
     image: outstand/metaractor:dev
     stdin_open: true

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-set -e
+set -euo pipefail
 
 su-exec ${FIXUID:?Missing FIXUID var}:${FIXGID:?Missing FIXGID var} fixuid
 
@@ -27,7 +27,7 @@ if [ "$1" = 'bundle' ]; then
 elif ls /usr/local/bundle/bin | grep -q "\b$1\b"; then
   set -- su-exec metaractor bundle exec "$@"
 
-  su-exec metaractor ash -c 'bundle check || bundle install'
+  su-exec metaractor bash -c 'bundle check || bundle install'
 fi
 
 exec "$@"

--- a/lib/metaractor/errors.rb
+++ b/lib/metaractor/errors.rb
@@ -71,18 +71,19 @@ module Metaractor
 
     def add(error: {}, errors: {}, object: nil)
       trees = []
-      [error, errors].each do |h| 
+      [error, errors].each do |h|
         tree = nil
         if h.is_a? Metaractor::Errors
           tree = Sycamore::Tree.from(h.instance_variable_get(:@tree))
         else
-          tree = Sycamore::Tree.from(h)
+          tree = Sycamore::Tree.from(h.to_h)
         end
 
         unless tree.empty?
-          if tree.nodes.any? {|node| tree.strict_leaf?(node) }
+          if tree.nodes.any? { |node| tree.strict_leaf?(node) }
             raise ArgumentError, "Invalid hash!"
           end
+
           trees << tree
         end
       end

--- a/spec/metaractor_spec.rb
+++ b/spec/metaractor_spec.rb
@@ -501,6 +501,10 @@ describe Metaractor do
 
         errors = Metaractor::Errors.new
         expect { errors.add(errors: messages) }.to_not raise_error
+
+        expect(errors).to include(
+          user: "must be awesome"
+        )
       end
     end
 

--- a/spec/metaractor_spec.rb
+++ b/spec/metaractor_spec.rb
@@ -497,7 +497,7 @@ describe Metaractor do
       end
 
       it "handles a delegated error hash" do
-        messages = SimpleDelegator.new({ user: ["must be awesome"] })
+        messages = SimpleDelegator.new({ user: SimpleDelegator.new(["must be awesome"]) })
 
         errors = Metaractor::Errors.new
         expect { errors.add(errors: messages) }.to_not raise_error

--- a/spec/metaractor_spec.rb
+++ b/spec/metaractor_spec.rb
@@ -495,6 +495,13 @@ describe Metaractor do
           user: { title: 'cannot be blank' }
         })
       end
+
+      it "handles a delegated error hash" do
+        messages = SimpleDelegator.new({ user: ["must be awesome"] })
+
+        errors = Metaractor::Errors.new
+        expect { errors.add(errors: messages) }.to_not raise_error
+      end
     end
 
     context 'i18n' do


### PR DESCRIPTION
Rails is helpfully passing us a SimpleDelegator to warn about deprecations. Sycamore doesn't know how to correctly process a hash wrapped in a delegator and we end up with a malformed tree. I've added a `to_h` to unwrap the delegator.

I've also updated the docker stuff and corresponding buildkite setup.